### PR TITLE
fix: update CORS configuration to allow production frontend URLs

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -17,7 +17,10 @@ const PORT: number = parseInt(process.env.PORT || '3003', 10);
 
 // Middleware
 app.use(cors({
-  origin: 'http://localhost:3002', // Frontend URL
+  origin: [
+    'http://localhost:3002', // Local frontend
+    'https://apollo-reddit-scraper-frontend.vercel.app', // Production frontend
+  ],
   credentials: true
 }));
 app.use(express.json());


### PR DESCRIPTION
## Fix CORS Configuration for Production Frontend URLs

### Description
This PR updates the backend CORS configuration to properly allow requests from the production frontend URL. This resolves the CORS policy errors that were blocking API requests from the deployed frontend application.

### Changes Made
- Updated CORS origin configuration in `src/server.ts` to include production frontend URLs
- Added `https://apollo-reddit-scraper-frontend.vercel.app` to allowed origins array
- Maintained existing localhost development URL for local testing

### Benefits
- Resolves CORS policy errors preventing API calls from production frontend
- Enables proper communication between deployed frontend and backend services
- Maintains security by explicitly allowing only trusted domains
- Ensures consistent API functionality across development and production environments

### Testing
- Verified CORS configuration allows both local and production frontend URLs
- Confirmed existing development workflow remains unaffected
- Backend successfully accepts requests from production frontend domains
- No breaking changes to existing API endpoints or functionality