### PR TITLE
Fix Blog Creator 404 errors with proper Vercel routing

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -31,15 +31,15 @@ app.use(cors({
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
-// API Routes - Vercel handles the /api prefix
-app.use('/reddit', redditRoutes);
-app.use('/analysis', analysisRoutes);
-app.use('/sheets', sheetsRoutes);
-app.use('/workflow', workflowRoutes);
-app.use('/chat', chatRoutes);
-app.use('/content', contentRoutes);
-app.use('/playbooks', playbooksRoutes);
-app.use('/blog-creator', blogCreatorRoutes);
+// API Routes
+app.use('/api/reddit', redditRoutes);
+app.use('/api/analysis', analysisRoutes);
+app.use('/api/sheets', sheetsRoutes);
+app.use('/api/workflow', workflowRoutes);
+app.use('/api/chat', chatRoutes);
+app.use('/api/content', contentRoutes);
+app.use('/api/playbooks', playbooksRoutes);
+app.use('/api/blog-creator', blogCreatorRoutes);
 
 // Health check endpoint
 app.get('/health', (req: Request, res: Response<HealthCheckResponse>): void => {

--- a/vercel.json
+++ b/vercel.json
@@ -2,21 +2,21 @@
   "version": 2,
   "public": true,
   "alias": ["apollo-reddit-scraper-backend.vercel.app"],
-  "builds": [
-    {
-      "src": "api/index.ts",
-      "use": "@vercel/node"
+  "functions": {
+    "api/index.ts": {
+      "memory": 1024,
+      "maxDuration": 30
     }
-  ],
+  },
   "rewrites": [
     {
-      "source": "/api/(.*)",
-      "destination": "/api/index/$1"
+      "source": "/(.*)",
+      "destination": "/api"
     }
   ],
   "headers": [
     {
-      "source": "/api/(.*)",
+      "source": "/(.*)",
       "headers": [
         {
           "key": "Access-Control-Allow-Origin",


### PR DESCRIPTION
- Updated vercel.json to use functions configuration with proper rewrite
- Fixed Express route configuration to handle /api prefixes correctly
- Tested and verified all Blog Creator endpoints are now accessible
- generate-content-async and job-status endpoints working properly

Resolves 404 errors when clicking Play button and Execute 5 Rows in production