### PR TITLE
feat(competitor-conquesting): persist async job status in serverlessafe store (Upstash Redis); fix 404 polling on Vercel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@mendable/firecrawl-js": "^1.29.3",
         "@sparticuz/chromium": "^119.0.0",
         "@types/snoowrap": "^1.16.1",
+        "@upstash/redis": "^1.34.3",
         "axios": "^1.11.0",
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
@@ -347,6 +348,15 @@
       "optional": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.35.3",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.35.3.tgz",
+      "integrity": "sha512-hSjv66NOuahW3MisRGlSgoszU2uONAY2l5Qo3Sae8OT3/Tng9K+2/cBRuyPBX8egwEGcNNCF9+r0V6grNnhL+w==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
       }
     },
     "node_modules/accepts": {
@@ -3321,6 +3331,12 @@
         "buffer": "^5.2.1",
         "through": "^2.3.8"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/undefsafe": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "openai": "^5.5.1",
     "puppeteer-core": "^22.8.2",
     "snoowrap": "^1.23.0",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "@upstash/redis": "^1.34.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",

--- a/src/services/jobStore.ts
+++ b/src/services/jobStore.ts
@@ -1,0 +1,130 @@
+/**
+ * Job Store (serverless-safe)
+ * Why this matters: Vercel serverless instances are ephemeral and not sticky.
+ * In-memory Maps lose data between invocations, causing 404 "Job not found" during polling.
+ * This module provides a shared store backed by Upstash Redis when available,
+ * with a safe in-memory fallback for local/dev.
+ */
+
+import type { Request } from 'express';
+
+// Optional Redis client (lazy)
+let redis: any = null;
+
+const hasUpstash = Boolean(
+  process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN
+);
+
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+export interface JobData {
+  status: 'running' | 'completed' | 'error';
+  progress?: number;
+  stage?: string;
+  message?: string;
+  keyword?: string;
+  url?: string;
+  result?: JsonValue;
+  error?: string | null;
+  startTime?: number;
+  timestamp?: number; // last update timestamp (ms)
+  [key: string]: JsonValue | undefined;
+}
+
+const DEFAULT_TTL_SECONDS = 2 * 60 * 60; // 2 hours
+
+// In-memory fallback for local/dev
+const memoryStore = new Map<string, JobData>();
+
+function getRedis() {
+  if (!hasUpstash) return null;
+  if (!redis) {
+    // Inline import to avoid bundling when not used
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { Redis } = require('@upstash/redis');
+    redis = new Redis({
+      url: process.env.UPSTASH_REDIS_REST_URL,
+      token: process.env.UPSTASH_REDIS_REST_TOKEN
+    });
+  }
+  return redis;
+}
+
+function jobKey(jobId: string): string {
+  return `cc_job:${jobId}`;
+}
+
+export async function createJob(
+  jobId: string,
+  data: JobData,
+  ttlSeconds: number = DEFAULT_TTL_SECONDS
+): Promise<void> {
+  const record: JobData = { ...data, timestamp: Date.now() };
+  const r = getRedis();
+  if (r) {
+    await r.set(jobKey(jobId), record, { ex: ttlSeconds });
+  } else {
+    memoryStore.set(jobId, record);
+  }
+}
+
+export async function updateJob(
+  jobId: string,
+  updates: Partial<JobData>,
+  ttlSeconds: number = DEFAULT_TTL_SECONDS
+): Promise<void> {
+  const r = getRedis();
+  if (r) {
+    const existing = (await r.get(jobKey(jobId))) as JobData | null;
+    const updated: JobData = { ...(existing || ({} as any)), ...updates, timestamp: Date.now() };
+    await r.set(jobKey(jobId), updated, { ex: ttlSeconds });
+  } else {
+    const existing = memoryStore.get(jobId) || ({} as JobData);
+    const updated: JobData = { ...existing, ...updates, timestamp: Date.now() };
+    memoryStore.set(jobId, updated);
+  }
+}
+
+export async function getJob(jobId: string): Promise<JobData | null> {
+  const r = getRedis();
+  if (r) {
+    const data = (await r.get(jobKey(jobId))) as JobData | null;
+    return data || null;
+  }
+  return memoryStore.get(jobId) || null;
+}
+
+export async function deleteJob(jobId: string): Promise<boolean> {
+  const r = getRedis();
+  if (r) {
+    const res = await r.del(jobKey(jobId));
+    return Boolean(res);
+  }
+  return memoryStore.delete(jobId);
+}
+
+export function isServerlessEphemeral(req?: Request): boolean {
+  // Heuristic: on Vercel, we often have these envs set
+  // The presence of VERCEL indicates serverless; if no Redis, warn in logs
+  const vercel = Boolean(process.env.VERCEL);
+  return vercel && !hasUpstash;
+}
+
+export function getStoreDiagnostics() {
+  return {
+    usingRedis: hasUpstash,
+    provider: hasUpstash ? 'upstash' : 'memory',
+    ttlSeconds: DEFAULT_TTL_SECONDS
+  } as const;
+}
+
+// Note: The caller should call createJob() initially, then updateJob() during progress,
+// and getJob() from polling handlers. Delete with deleteJob() when expired or cleaned.
+
+


### PR DESCRIPTION
## feat: Serverless-safe async job store for Competitor Conquesting (fix 404 job-status on Vercel)

### Description
Moves async job tracking from per-instance memory to a serverless-safe store (Upstash Redis) so Vercel cold starts or routing across instances no longer cause 404 “Job not found” during polling.

### Changes Made
- Added `src/services/jobStore.ts`
  - Serverless-aware job persistence with TTL (2h), using Upstash Redis when `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` are present; falls back to in-memory for local/dev.
- Updated `src/routes/competitorConquesting.ts`
  - Replaced in-memory `Map` usage with jobStore: `createJob`, `updateJob`, `getJob`, `deleteJob`.
  - Preserves existing API surface: `POST /api/competitor-conquesting/generate-content-async`, `GET /api/competitor-conquesting/job-status/:jobId`.
- Added dependency `@upstash/redis` to `package.json`.

### Benefits
- Eliminates production 404s on `job-status` caused by serverless instance swaps.
- Keeps long-running content generation reliable with consistent progress polling.
- Minimal blast radius; no API changes for frontend.

### Testing
- Local: Type-check clean (`npm run type-check`).
- Manual:
  1. Set `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` in Vercel backend env.
  2. Deploy preview.
  3. In frontend, run a competitor job and poll `GET /api/competitor-conquesting/job-status/{jobId}`.
  4. Observe 200 responses with progress instead of 404.