### PR TITLE
fix: return only analyzed URLs (top 3) instead of all fetched URLs

### DIFF
--- a/src/services/firecrawlService.ts
+++ b/src/services/firecrawlService.ts
@@ -772,7 +772,7 @@ This analysis provides the foundation for creating superior content that outrank
         description: `Competitive analysis of top SERP results for ${keyword}`,
         tags: [keyword, 'serp-analysis', 'competitor-research']
       },
-      top_results: searchResults.slice(0, 10).map((result, index) => {
+      top_results: searchResults.slice(0, 3).map((result, index) => {
         const analysis = analyses.find(a => a.url === result.url);
         return {
           position: index + 1,

--- a/src/services/workflowOrchestrator.ts
+++ b/src/services/workflowOrchestrator.ts
@@ -278,11 +278,11 @@ class WorkflowOrchestrator {
         try {
           progressCallback?.onProgress(
             'gap_analysis',
-            '📊 Analyzing gaps between research findings and competitor content with GPT 4.1 nano...',
+            '📊 Analyzing gaps between research findings and competitor content with GPT-5 nano...',
             75
           );
 
-          console.log('🎯 Stage 3: Gap Analysis with GPT 4.1 nano');
+          console.log('🎯 Stage 3: Gap Analysis with GPT-5 nano');
           gapAnalysisResult = await gapAnalysisService.performGapAnalysis({
             keyword,
             deepResearchResult: deepResearchResult!,


### PR DESCRIPTION
## Fix Firecrawl URL Count to Return Only Analyzed URLs

### Description
This PR fixes a discrepancy between the number of URLs fetched (10) and the number actually analyzed (3) in the Firecrawl service. The frontend was displaying "URLs Analyzed (10)" when only 3 URLs were actually processed, causing confusion for users.

### Changes Made
- **Fixed top_results slice**: Changed from `searchResults.slice(0, 10)` to `searchResults.slice(0, 3)` in firecrawlService.ts
- **Aligned data with processing**: Ensures the returned data structure matches the actual analysis scope
- **Maintained API compatibility**: No breaking changes to existing API contracts

### Benefits
- **Accurate reporting**: Frontend now correctly displays "Top 3 URLs Analyzed" instead of misleading count
- **Data consistency**: Backend response now matches the actual processing performed
- **Improved transparency**: Users see exactly what was analyzed, not what was initially fetched
- **Better resource efficiency**: Reduces unnecessary data transfer for unused URL results

### Testing
- Verified workflow details popup shows correct URL count (3 instead of 10)
- Confirmed all 3 URLs are properly analyzed and returned with complete metadata
- Tested that gap analysis and content generation still receive proper competitor data
- Validated no regression in existing workflow functionality