### PR TITLE
feat: increase token limits for comprehensive AI responses

### DIFF
--- a/src/services/claudeService.ts
+++ b/src/services/claudeService.ts
@@ -234,7 +234,7 @@ Generate a practical, action-oriented opening that identifies the engagement opp
     try {
       const completion = await this.client!.messages.create({
         model: "claude-sonnet-4-20250514", // Using Claude 3.5 Sonnet
-        max_tokens: 300,
+        max_tokens: 2000, // Increased from 300 to allow comprehensive socratic learning responses
         temperature: 0.7,
         system: systemPrompt,
         messages: [{ role: "user", content: initialPrompt }]
@@ -298,7 +298,7 @@ What angle feels most natural for your approach?`,
 
       const completion = await this.client!.messages.create({
         model: "claude-sonnet-4-20250514", // Using Claude 3.5 Sonnet
-        max_tokens: 400,
+        max_tokens: 2000, // Increased from 400 to allow comprehensive socratic learning responses
         temperature: 0.7,
         system: systemPrompt + "\n\n" + conversationHistory,
         messages: messages


### PR DESCRIPTION
## Increase Token Limits for Comprehensive AI Responses

### Description
This PR increases the token limits for Claude AI responses in the DigDeeperModal to enable complete, comprehensive socratic learning conversations without truncation.

### Changes Made
- Increased token limits from 300→2000 for initial chat messages
- Increased token limits from 400→2000 for follow-up chat messages
- Updated claudeService.ts with higher token allowances

### Benefits
- Eliminates message truncation in AI conversations
- Enables complete socratic learning responses
- Improves user experience in DigDeeperModal interactions
- Allows for more comprehensive sales coaching through guided discovery

### Testing
- Verified AI responses are no longer cut off mid-sentence
- Confirmed longer, more detailed coaching conversations
- Tested with various conversation lengths and complexity levels