### PR TITLE
fix: add missing VOC agent route to Vercel serverless deployment

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -30,6 +30,7 @@ import jokesRoutes from '../src/routes/jokes';
 import abTestingRoutes from '../src/routes/abTesting';
 import cacheInvalidationRoutes from '../src/routes/cacheInvalidation';
 import uncoverRoutes from '../src/routes/uncover';
+import vocAgentRoutes from '../src/routes/vocAgent';
 
 // Load environment variables
 dotenv.config();
@@ -82,6 +83,7 @@ app.use('/api/jokes', jokesRoutes);
 app.use('/api/ab-testing', abTestingRoutes);
 app.use('/api/cache-invalidation', cacheInvalidationRoutes);
 app.use('/api/uncover', uncoverRoutes);
+app.use('/api/voc-agent', vocAgentRoutes);
 
 // Health check endpoint
 app.get('/health', (req: Request, res: Response<HealthCheckResponse>): void => {
@@ -128,7 +130,8 @@ app.get('/', (req: Request, res: Response<ApiInfoResponse>): void => {
         jokes: '/api/jokes/*',
         abTesting: '/api/ab-testing/*',
         cacheInvalidation: '/api/cache-invalidation/*',
-        uncover: '/api/uncover/*'
+        uncover: '/api/uncover/*',
+        vocAgent: '/api/voc-agent/*'
       }
     }
   });

--- a/src/server.ts
+++ b/src/server.ts
@@ -124,7 +124,8 @@ app.get('/', (req: Request, res: Response<ApiInfoResponse>): void => {
         jokes: '/api/jokes/*',
         abTesting: '/api/ab-testing/*',
         cacheInvalidation: '/api/cache-invalidation/*',
-        uncover: '/api/uncover/*'
+        uncover: '/api/uncover/*',
+        vocAgent: '/api/voc-agent/*'
       }
     }
   });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -40,6 +40,7 @@ export interface ApiInfoResponse {
       abTesting: string;
       cacheInvalidation: string;
       uncover: string;
+      vocAgent: string;
     };
   };
 }


### PR DESCRIPTION
## Fix VOC Agent 404 Error in Vercel Production Deployment

### Description
This PR resolves the 404 error occurring when users click "Extract Customer Pain Points" on the /voice-of-customer-agent page in production. The issue was caused by the VOC agent route being missing from the Vercel serverless deployment configuration, even though it existed in the main server file.

### Changes Made
- **Added VOC Agent Route to Vercel Deployment** (`api/index.ts`): Import and register `vocAgentRoutes` for serverless function
- **Updated API Documentation** (`api/index.ts` & `src/server.ts`): Added `vocAgent: '/api/voc-agent/*'` to endpoints documentation
- **Fixed TypeScript Interface** (`src/types/index.ts`): Added `vocAgent: string` property to `ApiInfoResponse` interface
- **Route Registration**: Properly registered `/api/voc-agent` path in Vercel serverless configuration

### Benefits
- **Fixes Production 404 Error**: Users can now successfully use the "Extract Customer Pain Points" feature
- **Complete VOC Agent Functionality**: All VOC analysis endpoints now accessible in production
- **Consistent API Documentation**: Both development and production servers show complete endpoint listings
- **Type Safety**: TypeScript interface matches actual API structure
- **Improved User Experience**: No more broken functionality on the voice-of-customer-agent page

### Testing
- TypeScript compilation passes without errors
- All existing functionality preserved
- VOC agent routes properly registered in both development and production configurations
- API documentation endpoints updated to reflect complete feature set

### Root Cause
The VOC agent routes were added to `src/server.ts` (development) but not to `api/index.ts` (Vercel serverless), causing a discrepancy between local development and production deployment.

### Files Changed (3 files, +7 lines, -2 lines)
- `api/index.ts` (Vercel serverless function)
- `src/server.ts` (development server)
- `src/types/index.ts` (TypeScript interfaces)